### PR TITLE
T356 ui disable autocorrect

### DIFF
--- a/obi/ui/php/index.php
+++ b/obi/ui/php/index.php
@@ -95,7 +95,7 @@ function load_bento_boxes(){
       <form action='search-beta' method='GET' class='search-form'>
             <div class='search-all-label'><label>Search All</label></div>
             <div class='search-all-form-fields'>
-            <input aria-label='Enter your search terms' id='query' type='text' size='40' maxlength='100' name='query' value='<?php print htmlspecialchars($_GET["query"], ENT_QUOTES) ?>' />
+            <input aria-label='Enter your search terms' id='query' type='text' size='40' maxlength='100' name='query' value='<?php print htmlspecialchars($_GET["query"], ENT_QUOTES) ?>' autocomplete='off' autocorrect='off' autocapitalize='off' spellcheck='false' />
             <input type='submit' value='Search'/>
             </div>
       </form>

--- a/obi/ui/templates/home.html
+++ b/obi/ui/templates/home.html
@@ -87,7 +87,7 @@ function load_bento_boxes(){
 <div id='form'>
     <form action='{% url "home" %}' method='GET' class='form-search'>
         <fieldset>
-            <input id='q' type='text' size='40' name='q' placeholder='Search...' value='{{ q }}' class='input-large search-query' />
+            <input id='q' type='text' size='40' name='q' placeholder='Search...' value='{{ q }}' class='input-large search-query' autocomplete='off' autocorrect='off' autocapitalize='off' spellcheck='false' />
             <input type='submit' class='btn' value='go'/>
         </fieldset>
     </form>


### PR DESCRIPTION
Disables device browser/os autocorrect and autocapitalize and other text entry assist tools that can be overly aggressive and not helpful in this context. Fixes #356