### PR TITLE
Fixes #373 by moving loaded_count scope out of try block.

### DIFF
--- a/obi/ui/management/commands/load_databases.py
+++ b/obi/ui/management/commands/load_databases.py
@@ -24,11 +24,12 @@ class Command(BaseCommand):
         cursor.close()
         time.sleep(1)
 
+        loaded_count = 0
+
         try:
             r = requests.get(settings.LIBGUIDES_DB_URL)
             soup = BeautifulSoup(r.json()['data']['html'], "lxml")
             itemlists = soup.find_all('div', class_='s-lg-az-result')
-            loaded_count = 0
             for itemlist in itemlists:
                 name_div = itemlist.find('div', class_='s-lg-az-result-title')
                 if name_div is None:


### PR DESCRIPTION
To test: Corrupt the LIBGUIDES_DB_URL setting to cause the code in the `try` block to error out.  Note that the stack trace is for the root cause error, rather than the fact that `loaded_count` is not defined.