### PR TITLE
removing AND between query terms

### DIFF
--- a/obi/ui/views.py
+++ b/obi/ui/views.py
@@ -162,7 +162,6 @@ def _databases_solr_query(request):
         matches = []
         s = solr.SolrConnection(settings.SOLR_URL)
         if not q[0] == '\"':
-            q = " AND ".join(q.split())
             q = q.replace("\"", " ")
         query = u'+id:db-* +(name:(%s) OR description:(%s))' % (q, q)
         solr_response = s.query(query)
@@ -246,7 +245,6 @@ def _journals_solr_query(request):
         matches = []
         s = solr.SolrConnection(settings.SOLR_URL)
         if not q[0] == '\"':
-            q = " AND ".join(q.split())
             q = q.replace("\"", " ")
         query = u'+id:j-* +(name:(%s) OR text:(%s))' % (q, q)
         solr_response = s.query(query)


### PR DESCRIPTION
Fixes #420. Database and journal titles that match the search terms (even if they have the word "and" in them will be retrieved) and should still rank high. 